### PR TITLE
Improve sklearn compatibility

### DIFF
--- a/src/group_lasso/_fista.py
+++ b/src/group_lasso/_fista.py
@@ -2,6 +2,7 @@ import warnings
 from math import sqrt
 
 import numpy.linalg as la
+from sklearn.exceptions import ConvergenceWarning
 
 
 def _fista_momentum(momentum):
@@ -52,7 +53,7 @@ def fista(x0, grad, prox, loss, lipschitz, n_iter=10, tol=1e-6, callback=None):
         "You used subsampling then this is expected, otherwise,"
         "try to increase the number of iterations "
         "or decreasing the tolerance.",
-        RuntimeWarning,
+        ConvergenceWarning,
     )
 
     return optimal_x

--- a/src/group_lasso/_group_lasso.py
+++ b/src/group_lasso/_group_lasso.py
@@ -366,9 +366,7 @@ class BaseGroupLasso(ABC, BaseEstimator, TransformerMixin):
         """
         assert all(reg >= 0 for reg in self.group_reg_vector_)
         groups = np.array(self.groups)
-        assert len(self.group_reg_vector_) == len(
-            np.unique(groups[groups >= 0])
-        )
+        assert len(self.group_reg_vector_) == len(self.groups_)
         assert self.n_iter > 0
         assert self.tol >= 0
 
@@ -398,15 +396,18 @@ class BaseGroupLasso(ABC, BaseEstimator, TransformerMixin):
     def _init_fit(self, X, y, lipschitz):
         """Initialise model and check inputs.
         """
-        if self.groups is None:
+        groups = self.groups
+        if groups is None:
             # TODO: possibly drop a warning that group-lasso is not
             # functional if no groups are specified.
-            self.groups = np.arange(X.shape[1])
+            groups = np.arange(X.shape[1])
+        self.groups_init_ = groups.ravel() # Validated user setting
+        groups = np.array([-1 if i is None else i for i in groups])
+
         self.random_state_ = check_random_state(self.random_state)
         X, y, lipschitz = self._prepare_dataset(X, y, lipschitz)
-        groups = np.array([-1 if i is None else i for i in self.groups])
 
-        self.groups_ = [self.groups == u for u in np.unique(groups) if u >= 0]
+        self.groups_ = [groups == u for u in np.unique(groups) if u >= 0]
         self.group_reg_vector_ = self._get_reg_vector(self.group_reg)
         self.losses_ = []
 
@@ -466,10 +467,9 @@ class BaseGroupLasso(ABC, BaseEstimator, TransformerMixin):
 
     @property
     def chosen_groups_(self):
-        """A set of the coosen group ids.
+        """A set of the chosen group ids.
         """
-        sparsity_mask = self._get_chosen_coef_mask(self.coef_)
-        return set(np.unique(self.groups.ravel()[sparsity_mask.ravel()]))
+        return set(self.groups_init_[self.sparsity_mask_.ravel()])
 
     def transform(self, X):
         """Remove columns corresponding to zero-valued coefficients.

--- a/src/group_lasso/_group_lasso.py
+++ b/src/group_lasso/_group_lasso.py
@@ -859,7 +859,7 @@ class LogisticGroupLasso(BaseGroupLasso, ClassifierMixin):
         """
         check_is_fitted(self, ['X_', 'y_'])
         X = check_array(X)
-        return np.argmax(self.predict_proba(X), axis=0)[:, np.newaxis]
+        return np.argmax(self.predict_proba(X), axis=0)
 
     def _encode(self, y):
         """One-hot encoding for the labels.

--- a/src/group_lasso/_group_lasso.py
+++ b/src/group_lasso/_group_lasso.py
@@ -624,7 +624,7 @@ class GroupLasso(BaseGroupLasso, RegressorMixin):
             old_regularisation=old_regularisation,
             supress_warning=supress_warning,
         )
-        self.frobenius_lipchitz = frobenius_lipschitz
+        self.frobenius_lipschitz = frobenius_lipschitz
 
     def fit(self, X, y, lipschitz=None):
         """Fit a group lasso regularised linear regression model.
@@ -660,7 +660,7 @@ class GroupLasso(BaseGroupLasso, RegressorMixin):
 
     def _compute_lipschitz(self, X, y):
         num_rows, num_cols = X.shape
-        if self.frobenius_lipchitz:
+        if self.frobenius_lipschitz:
             if sparse.issparse(X):
                 return sparse.linalg.norm(X, "fro") ** 2 / num_rows
             return la.norm(X, "fro") ** 2 / num_rows

--- a/src/group_lasso/_group_lasso.py
+++ b/src/group_lasso/_group_lasso.py
@@ -808,6 +808,14 @@ class LogisticGroupLasso(BaseGroupLasso, ClassifierMixin):
             supress_warning=supress_warning,
         )
 
+    def _more_tags(self):
+        """
+        This is used only for testing. At the moment, LogisticGroupLasso()
+        supports binary classification only. See here what tags are possible:
+        https://scikit-learn.org/stable/developers/develop.html
+        """
+        return {"binary_only": True}
+
     def _compute_proba(self, X, w):
         return _softmax_proba(X, w)
 

--- a/src/group_lasso/_group_lasso.py
+++ b/src/group_lasso/_group_lasso.py
@@ -860,7 +860,7 @@ class LogisticGroupLasso(BaseGroupLasso, ClassifierMixin):
     def predict_proba(self, X):
         check_is_fitted(self, ['X_', 'y_'])
         X = check_array(X)
-        return _softmax_proba(X, self.coef_).T
+        return _softmax_proba(X, self.coef_)
 
     def predict(self, X):
         """Predict using the linear model.
@@ -873,7 +873,7 @@ class LogisticGroupLasso(BaseGroupLasso, ClassifierMixin):
         # should have meaningful values as well...
         if len(self.classes_) == 1:
             return self.classes_[0]*np.ones(len(X))
-        y_pred = np.argmax(self.predict_proba(X), axis=0)
+        y_pred = np.argmax(self.predict_proba(X), axis=1)
         return self._decode(y_pred)
 
     def _encode(self, y):

--- a/src/group_lasso/_group_lasso.py
+++ b/src/group_lasso/_group_lasso.py
@@ -422,6 +422,7 @@ class BaseGroupLasso(ABC, BaseEstimator, TransformerMixin):
         """
         self._init_fit(X, y, lipschitz=lipschitz)
         self._minimise_loss()
+        return self
 
     @abstractmethod
     def predict(self, X):  # pragma: nocover
@@ -622,7 +623,7 @@ class GroupLasso(BaseGroupLasso, RegressorMixin):
             A Lipshitz bound for the mean squared loss with the given
             data and target matrices. If None, this is estimated.
         """
-        super().fit(X, y, lipschitz=lipschitz)
+        return super().fit(X, y, lipschitz=lipschitz)
 
     def predict(self, X):
         """Predict using the linear model.

--- a/src/group_lasso/_group_lasso.py
+++ b/src/group_lasso/_group_lasso.py
@@ -404,7 +404,7 @@ class BaseGroupLasso(ABC, BaseEstimator, TransformerMixin):
             # TODO: possibly drop a warning that group-lasso is not
             # functional if no groups are specified.
             groups = np.arange(X.shape[1])
-        self.groups_init_ = groups.ravel() # Validated user setting
+        self.groups_init_ = np.asarray(groups).ravel() # Validated user setting
         groups = np.array([-1 if i is None else i for i in groups])
 
         self.random_state_ = check_random_state(self.random_state)

--- a/src/group_lasso/_group_lasso.py
+++ b/src/group_lasso/_group_lasso.py
@@ -859,6 +859,12 @@ class LogisticGroupLasso(BaseGroupLasso, ClassifierMixin):
         """
         check_is_fitted(self, ['X_', 'y_'])
         X = check_array(X)
+        # CHECK: not exactly sure how to handle the one-label case, where
+        # fit(X,y) received a y with just one label. This solves a check
+        # for the sklearn interface, but the other states (self.coef_, ...)
+        # should have meaningful values as well...
+        if len(self.classes_) == 1:
+            return self.classes_[0]*np.ones(len(X))
         return np.argmax(self.predict_proba(X), axis=0)
 
     def _encode(self, y):

--- a/src/group_lasso/_group_lasso.py
+++ b/src/group_lasso/_group_lasso.py
@@ -166,7 +166,7 @@ class BaseGroupLasso(ABC, BaseEstimator, TransformerMixin):
 
     def __init__(
         self,
-        groups,
+        groups=None,
         group_reg=0.05,
         l1_reg=0.00,
         n_iter=100,
@@ -393,6 +393,10 @@ class BaseGroupLasso(ABC, BaseEstimator, TransformerMixin):
     def _init_fit(self, X, y, lipschitz):
         """Initialise model and check inputs.
         """
+        if self.groups is None:
+            # TODO: possibly drop a warning that group-lasso is not
+            # functional if no groups are specified.
+            self.groups = np.arange(X.shape[1])
         self.random_state_ = check_random_state(self.random_state)
         X, y, lipschitz = self._prepare_dataset(X, y, lipschitz)
         groups = np.array([-1 if i is None else i for i in self.groups])
@@ -756,7 +760,7 @@ class LogisticGroupLasso(BaseGroupLasso, ClassifierMixin):
 
     def __init__(
         self,
-        groups,
+        groups=None,
         group_reg=0.05,
         l1_reg=0.05,
         n_iter=100,

--- a/src/group_lasso/_group_lasso.py
+++ b/src/group_lasso/_group_lasso.py
@@ -646,7 +646,8 @@ class GroupLasso(BaseGroupLasso, RegressorMixin):
         """
         X = check_array(X, accept_sparse=True)
         check_is_fitted(self, "is_fitted_")
-        return self.intercept_ + X @ self.coef_
+        y_pred = self.intercept_ + X @ self.coef_
+        return y_pred.squeeze()
 
     def _unregularised_loss(self, X, y, w):
         X_, y_ = self.subsample(X, y)

--- a/src/group_lasso/_group_lasso.py
+++ b/src/group_lasso/_group_lasso.py
@@ -372,10 +372,13 @@ class BaseGroupLasso(ABC, BaseEstimator, TransformerMixin):
 
     def _prepare_dataset(self, X, y, lipschitz):
         """Ensure that the inputs are valid and prepare them for fit.
+
+        CHECK: isn't this specific to GroupLasso - LogisticGroupLasso has
+               it's own _prepare_dataset...?
         """
         check_consistent_length(X, y)
         X = check_array(X, accept_sparse="csr")
-        y = check_array(y)
+        y = check_array(y, ensure_2d=False)
         if len(y.shape) == 1:
             y = y.reshape(-1, 1)
 

--- a/src/group_lasso/_group_lasso.py
+++ b/src/group_lasso/_group_lasso.py
@@ -846,8 +846,7 @@ class LogisticGroupLasso(BaseGroupLasso, ClassifierMixin):
         # Checks for input arrays in super().fit().
         ret = super().fit(X, y, lipschitz=lipschitz)
         self.classes_ = unique_labels(y)
-        self.X_ = X
-        self.y_ = y
+        check_is_fitted(self, ['X_', 'y_'])
         return ret
 
     def predict_proba(self, X):

--- a/src/group_lasso/_group_lasso.py
+++ b/src/group_lasso/_group_lasso.py
@@ -865,7 +865,8 @@ class LogisticGroupLasso(BaseGroupLasso, ClassifierMixin):
         # should have meaningful values as well...
         if len(self.classes_) == 1:
             return self.classes_[0]*np.ones(len(X))
-        return np.argmax(self.predict_proba(X), axis=0)
+        y_pred = np.argmax(self.predict_proba(X), axis=0)
+        return self._decode(y_pred)
 
     def _encode(self, y):
         """One-hot encoding for the labels.
@@ -875,6 +876,10 @@ class LogisticGroupLasso(BaseGroupLasso, ClassifierMixin):
             ones = np.ones((y.shape[0], 1))
             y = np.hstack(((ones - y.sum(1, keepdims=True)), y,))
         return y
+
+    def _decode(self, y):
+        # CHECK: Is this robust???
+        return self.label_binarizer_.classes_[y]
 
     def _prepare_dataset(self, X, y, lipschitz):
         """Ensure that the inputs are valid and prepare them for fit.

--- a/test/test_group_lasso.py
+++ b/test/test_group_lasso.py
@@ -6,11 +6,20 @@ import numpy.linalg as la
 import pytest
 from scipy import sparse
 from sklearn.linear_model import LinearRegression, LogisticRegression
+from sklearn.utils.estimator_checks import parametrize_with_checks
 from sklearn.preprocessing import LabelBinarizer
 
 from group_lasso import _group_lasso
 
 np.random.seed(0)
+
+
+# sklearn compatibility checks for the estimators.
+@parametrize_with_checks([_group_lasso.GroupLasso,
+                          _group_lasso.LogisticGroupLasso,
+                         ])
+def test_sklearn_compatible_estimator(estimator, check):
+    check(estimator)
 
 
 @pytest.mark.parametrize("reg", np.logspace(-3, 1, 10))


### PR DESCRIPTION
Hi Ynge

Again me... Probably it's already an issue on your backlog: The estimators do not fully comply with the sklearn interface: [Rolling your own estimator](https://scikit-learn.org/stable/developers/develop.html#rolling-your-own-estimator). I also found this [template](https://github.com/scikit-learn-contrib/project-template/blob/master/skltemplate/_template.py) useful. 

I had a look at this today and was able to pass sklearn's compatibility checks with a couple of edits. I added a corresponding test-case in test/test_group_lasso.py.

Unfortunately, while sklearn now is happy, I broke some of the tests that have `y` as a multi-label with `y.shape[1]>1`. I wasn't able to fix this right away (it got late here)... I'm confident that you're more efficient in fixing these issues anyways. Take my commits as suggestions.

HTH

**Update**
Note: For sklearn compatibility checks to pass, I had to set `l1_reg=0` and `group_reg=0`, because `LogisticGroupLasso` has quite some convergence problems, which sklearn does not tolerate. (One might set could set the [`poor_score`](https://scikit-learn.org/stable/developers/develop.html#rolling-your-own-estimator) tag, but that's not what we want.)


---

To check sklearn compatibility:
```python
from sklearn.utils.estimator_checks import parametrize_with_checks, check_estimator
from group_lasso import GroupLasso, LogisticGroupLasso

# The actual checks.
check_estimator(GroupLasso)
check_estimator(LogisticGroupLasso)

# As test case.
@parametrize_with_checks([GroupLasso, LogisticGroupLasso])
def test_sklearn_compatible_estimator(estimator, check):
    check(estimator)
```

Rough overview:

- Constructor argument "groups" requires default argument. I suggest `None`, which is interpreted as "each feature forms its own group".
- `fit()` should return `self`
- Added some missing input checks
- sklearn by default squeezes prediction output to 1d arrays (unless multi-label output is enforced, not supported yet)
- Issue a [sklearn ConvergencWarning](https://scikit-learn.org/stable/modules/generated/sklearn.exceptions.ConvergenceWarning.html) 
 instead of a RuntimeWarning if FISTA fails to converge
- `LogisticGroupLasso`: lacks member `classes_`
- `LogisticGroupLasso`: decode result - my fix likely isn't very safe
- Fix several minor things, typos, matrix shape issues